### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "redocly preview-docs",
-    "build": "redocly bundle openapi-definitions/openapi.yaml -o docs/openapi.yaml",
+    "build": "redocly bundle openapi-definitions/openapi.yaml -o docs/openapi.yaml && cp markdown/README.md docs/docs.md",
     "test": "redocly lint",
     "test-config": "redocly check-config",
     "check-updates": "echo 'TO UPDATE, RUN: npm install package-name' && npm outdated --depth=0"


### PR DESCRIPTION
Automatically copy the markdown-formatted developer documentation to the docs folder for public availability